### PR TITLE
Fix recursive ExceptionObjHolderImpl crash in exception reporting

### DIFF
--- a/nsexception-kt-core/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/core/NSException.kt
+++ b/nsexception-kt-core/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/core/NSException.kt
@@ -38,7 +38,7 @@ public fun addReporter(
  * of the [causes][Throwable.cause] will be appended, else causes are ignored.
  */
 @OptIn(UnsafeNumber::class, ExperimentalForeignApi::class)
-internal fun Throwable.asNSException(appendCausedBy: Boolean = false): NSException {
+internal fun Throwable.asNSException(appendCausedBy: Boolean = false): NSException = try {
     val returnAddresses = getFilteredStackTraceAddresses().let { addresses ->
         if (!appendCausedBy) return@let addresses
         addresses.toMutableList().apply {
@@ -46,10 +46,10 @@ internal fun Throwable.asNSException(appendCausedBy: Boolean = false): NSExcepti
                 addAll(cause.getFilteredStackTraceAddresses(true, addresses))
             }
         }
-    }.map {
-        NSNumber(unsignedInteger = it.convert<NSUInteger>())
-    }
-    return ThrowableNSException(name, getReason(appendCausedBy), returnAddresses)
+    }.map { NSNumber(unsignedInteger = it.convert<NSUInteger>()) }
+    ThrowableNSException(name, getReason(appendCausedBy), returnAddresses)
+} catch (e: Throwable) {
+    ThrowableNSException(name, message, emptyList())
 }
 
 /**


### PR DESCRIPTION
Add re-entrancy guards and exception handling to prevent crashes when exceptions are thrown during exception conversion or Crashlytics reporting.

- Add atomic guard in unhandled exception hook wrapper
- Add re-entrancy protection in Crashlytics reporter
- Add try-catch fallback in exception conversion to NSException
- Prevent recursive termination handler invocation

Fixes crash: Fatal Exception: (anonymous namespace)::ExceptionObjHolderImpl